### PR TITLE
Feature exploration and suggestions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    "@next/next/no-img-element": "off"
-  }
-}

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import { useSession } from '@/lib/auth-client'
+import Container from '@/components/shared/containers/container'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
+import { Bookmark, Heart, History, LogIn, User } from 'lucide-react'
+
+import { LibraryWatchlist } from '@/components/features/watchlist/library-watchlist'
+import { MyFavorites } from '@/components/features/watchlist/my-favorites'
+import RecentlyWatchedComponent from '@/components/features/watchlist/recently-watched'
+import { useUserFavorites, useUserRecentlyWatched, useUserWatchlist } from '@/hooks/use-user-data'
+
+interface LibraryStatCardProps {
+	label: string
+	value: number
+	icon: React.ReactNode
+	className?: string
+}
+
+function LibraryStatCard({ label, value, icon, className }: LibraryStatCardProps) {
+	return (
+		<Card
+			className={cn(
+				'bg-background/40 backdrop-blur-xl border-border/50 p-4',
+				'hover:border-border/80 transition-all duration-300 hover:shadow-lg',
+				className
+			)}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<div className="flex h-10 w-10 items-center justify-center rounded-xl bg-foreground/[0.08] border border-border/50">
+						{icon}
+					</div>
+					<div className="min-w-0">
+						<p className="text-2xl font-bold text-foreground leading-tight">{value}</p>
+						<p className="text-xs text-muted-foreground font-medium">{label}</p>
+					</div>
+				</div>
+			</div>
+		</Card>
+	)
+}
+
+function SignInFirst() {
+	return (
+		<div className="min-h-screen mt-20 bg-background">
+			<div className="relative w-full overflow-hidden bg-gradient-to-b from-zinc-950 via-zinc-950/95 to-zinc-950 border-b border-white/5">
+				<Container className="relative py-10 md:py-14">
+					<div className="max-w-3xl">
+						<p className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-[0.18em]">
+							Library
+						</p>
+						<h1 className="mt-2 text-3xl md:text-5xl font-bold tracking-tight text-foreground">
+							Sign in first
+						</h1>
+						<p className="mt-3 text-sm md:text-base text-muted-foreground max-w-2xl">
+							Your Library keeps your watchlist, favorites, and continue-watching progress synced
+							across devices.
+						</p>
+						<div className="mt-6 flex flex-wrap items-center gap-3">
+							<Button asChild className="gap-2">
+								<Link href="/auth/signin?callbackUrl=/library">
+									<LogIn className="h-4 w-4" />
+									Sign in
+								</Link>
+							</Button>
+							<Button asChild variant="outline" className="gap-2">
+								<Link href="/auth/signin?callbackUrl=/profile">
+									<User className="h-4 w-4" />
+									Account
+								</Link>
+							</Button>
+						</div>
+					</div>
+				</Container>
+			</div>
+
+			<Container className="py-8 md:py-12">
+				<div className="grid gap-3 sm:grid-cols-3">
+					<LibraryStatCard
+						label="Watchlist"
+						value={0}
+						icon={<Bookmark className="h-5 w-5 text-foreground" />}
+					/>
+					<LibraryStatCard
+						label="Favorites"
+						value={0}
+						icon={<Heart className="h-5 w-5 text-foreground" />}
+					/>
+					<LibraryStatCard
+						label="Continue watching"
+						value={0}
+						icon={<History className="h-5 w-5 text-foreground" />}
+					/>
+				</div>
+			</Container>
+		</div>
+	)
+}
+
+export default function LibraryPage() {
+	const { data: session, isPending } = useSession()
+
+	// DB-backed counts (only enabled when signed in)
+	const { data: dbWatchlistMovies = [] } = useUserWatchlist('movie')
+	const { data: dbWatchlistTV = [] } = useUserWatchlist('tv')
+	const { data: dbFavoritesMovies = [] } = useUserFavorites('movie')
+	const { data: dbFavoritesTV = [] } = useUserFavorites('tv')
+	const { data: dbRecentlyWatched = [] } = useUserRecentlyWatched()
+
+	const counts = React.useMemo(() => {
+		return {
+			watchlist: dbWatchlistMovies.length + dbWatchlistTV.length,
+			favorites: dbFavoritesMovies.length + dbFavoritesTV.length,
+			recent: dbRecentlyWatched.length
+		}
+	}, [dbWatchlistMovies.length, dbWatchlistTV.length, dbFavoritesMovies.length, dbFavoritesTV.length, dbRecentlyWatched.length])
+
+	if (isPending) {
+		return (
+			<div className="min-h-screen flex items-center justify-center">
+				<div className="h-8 w-8 animate-spin rounded-full border-2 border-foreground/20 border-t-foreground" />
+			</div>
+		)
+	}
+
+	if (!session) return <SignInFirst />
+
+	return (
+		<div className="min-h-screen mt-20 bg-background">
+			<div className="relative w-full overflow-hidden bg-gradient-to-b from-zinc-950 via-zinc-950/95 to-zinc-950 border-b border-white/5">
+				<Container className="relative py-10 md:py-14">
+					<div className="max-w-4xl">
+						<p className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-[0.18em]">
+							Library
+						</p>
+						<h1 className="mt-2 text-3xl md:text-5xl font-bold tracking-tight text-foreground">
+							Your Library
+						</h1>
+						<p className="mt-3 text-sm md:text-base text-muted-foreground max-w-2xl">
+							Everything you saved in one place: watchlist, favorites, and continue-watching.
+						</p>
+					</div>
+				</Container>
+			</div>
+
+			<Container className="py-8 md:py-12">
+				<div className="grid gap-3 sm:grid-cols-3">
+					<LibraryStatCard
+						label="Watchlist"
+						value={counts.watchlist}
+						icon={<Bookmark className="h-5 w-5 text-foreground" />}
+					/>
+					<LibraryStatCard
+						label="Favorites"
+						value={counts.favorites}
+						icon={<Heart className="h-5 w-5 text-foreground" />}
+					/>
+					<LibraryStatCard
+						label="Continue watching"
+						value={counts.recent}
+						icon={<History className="h-5 w-5 text-foreground" />}
+					/>
+				</div>
+
+				<Card className="mt-6 bg-background/40 backdrop-blur-xl border-border/50">
+					<div className="p-4 md:p-6">
+						<Tabs defaultValue="continue" className="w-full">
+							<TabsList className="w-full justify-start bg-transparent border border-border/50 rounded-xl p-1">
+								<TabsTrigger value="continue" className="gap-2">
+									<History className="h-4 w-4" />
+									Continue watching
+								</TabsTrigger>
+								<TabsTrigger value="watchlist" className="gap-2">
+									<Bookmark className="h-4 w-4" />
+									Watchlist
+								</TabsTrigger>
+								<TabsTrigger value="favorites" className="gap-2">
+									<Heart className="h-4 w-4" />
+									Favorites
+								</TabsTrigger>
+							</TabsList>
+
+							<TabsContent value="continue" className="mt-6">
+								{counts.recent > 0 ? (
+									<RecentlyWatchedComponent />
+								) : (
+									<div className="flex flex-col items-center justify-center py-16 space-y-4">
+										<div className="w-16 h-16 rounded-full bg-zinc-900 flex items-center justify-center mb-2">
+											<History className="w-8 h-8 text-zinc-600" />
+										</div>
+										<h3 className="text-xl font-bold text-foreground">No recent activity</h3>
+										<p className="text-muted-foreground text-center max-w-md">
+											Start watching a show or movie and it will show up here so you can resume
+											instantly.
+										</p>
+									</div>
+								)}
+							</TabsContent>
+
+							<TabsContent value="watchlist" className="mt-6">
+								<LibraryWatchlist />
+							</TabsContent>
+
+							<TabsContent value="favorites" className="mt-6">
+								<MyFavorites />
+							</TabsContent>
+						</Tabs>
+					</div>
+				</Card>
+			</Container>
+		</div>
+	)
+}
+

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -344,7 +344,10 @@ export default function ProfilePage() {
 											variant="outline"
 											size="sm"
 											className="border-red-500/20 hover:bg-red-500/10 hover:border-red-500/40 text-red-400"
-											onClick={() => signOut({ callbackUrl: '/' })}
+											onClick={async () => {
+												await signOut();
+												router.push('/');
+											}}
 										>
 											<LogOut className="w-4 h-4 mr-2" />
 											Sign Out

--- a/components/features/watchlist/library-favorites-synced.tsx
+++ b/components/features/watchlist/library-favorites-synced.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import * as React from 'react'
+import { Heart } from 'lucide-react'
+
+import { useHasMounted } from '@/hooks/use-has-mounted'
+import { useFavoritesStore } from '@/store/favoritesStore'
+import { fetchDetailsTMDB } from '@/lib/api'
+import type { Show } from '@/lib/types'
+import MediaCard from '@/components/features/media/card/media-card'
+import { cn } from '@/lib/utils'
+
+interface FavoriteRef {
+	id: number
+	type: 'movie' | 'tv'
+}
+
+function toFavoriteRefs(favoriteMovies: any[], favoriteTV: any[]) {
+	const refs: FavoriteRef[] = []
+
+	for (const item of favoriteMovies) {
+		if (typeof item?.id === 'number') refs.push({ id: item.id, type: 'movie' })
+	}
+
+	for (const item of favoriteTV) {
+		if (typeof item?.id === 'number') refs.push({ id: item.id, type: 'tv' })
+	}
+
+	return refs
+}
+
+function toDisplayShow(item: any, type: 'movie' | 'tv'): Show | null {
+	if (!item || typeof item !== 'object') return null
+
+	const hasImage = Boolean(item.poster_path || item.backdrop_path)
+	if (!hasImage) return null
+
+	return { ...(item as Show), media_type: type }
+}
+
+export function LibraryFavoritesSynced() {
+	const hasMounted = useHasMounted()
+	const { favoriteMovies, favoriteTV } = useFavoritesStore()
+
+	const favoriteRefs = React.useMemo(() => {
+		return toFavoriteRefs(favoriteMovies, favoriteTV)
+	}, [favoriteMovies, favoriteTV])
+
+	const [favorites, setFavorites] = React.useState<Show[]>([])
+	const [isLoading, setIsLoading] = React.useState(true)
+
+	React.useEffect(() => {
+		if (!hasMounted) return
+
+		let isCancelled = false
+
+		const load = async () => {
+			if (favoriteRefs.length === 0) {
+				setFavorites([])
+				setIsLoading(false)
+				return
+			}
+
+			setIsLoading(true)
+
+			try {
+				const uniqueKey = (ref: FavoriteRef) => `${ref.type}:${ref.id}`
+				const seen = new Set<string>()
+				const uniqueRefs: FavoriteRef[] = []
+
+				for (const ref of favoriteRefs) {
+					const key = uniqueKey(ref)
+					if (seen.has(key)) continue
+					seen.add(key)
+					uniqueRefs.push(ref)
+				}
+
+				const results = await Promise.all(
+					uniqueRefs.map(async (ref) => {
+						const localSource = ref.type === 'movie'
+							? favoriteMovies.find((item) => item?.id === ref.id)
+							: favoriteTV.find((item) => item?.id === ref.id)
+
+						const localShow = toDisplayShow(localSource, ref.type)
+						if (localShow) return localShow
+
+						try {
+							const data = await fetchDetailsTMDB(String(ref.id), ref.type)
+							return { ...(data as Show), media_type: ref.type }
+						} catch (error) {
+							console.error(`Failed to load favorite ${ref.type}:${ref.id}`, error)
+							return null
+						}
+					})
+				)
+
+				const valid = results.filter((item): item is Show => Boolean(item))
+				if (!isCancelled) setFavorites(valid)
+			} finally {
+				if (!isCancelled) setIsLoading(false)
+			}
+		}
+
+		load()
+
+		return () => {
+			isCancelled = true
+		}
+	}, [hasMounted, favoriteRefs, favoriteMovies, favoriteTV])
+
+	const movieFavorites = React.useMemo(() => {
+		return favorites.filter((show) => show.media_type === 'movie')
+	}, [favorites])
+
+	const tvFavorites = React.useMemo(() => {
+		return favorites.filter((show) => show.media_type === 'tv')
+	}, [favorites])
+
+	if (!hasMounted || isLoading) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<div className="text-center space-y-4">
+					<div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
+					<p className="text-muted-foreground text-sm">Loading favorites...</p>
+				</div>
+			</div>
+		)
+	}
+
+	if (favorites.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center py-20 space-y-4">
+				<div className="w-16 h-16 rounded-full bg-zinc-900 flex items-center justify-center mb-4">
+					<Heart className="w-8 h-8 text-zinc-600" />
+				</div>
+				<h3 className="text-xl font-bold text-foreground">No favorites yet</h3>
+				<p className="text-muted-foreground text-center max-w-md">
+					Start adding shows and movies to your favorites by clicking the heart icon on any details page.
+				</p>
+			</div>
+		)
+	}
+
+	return (
+		<div className="space-y-10">
+			<div>
+				<h2 className="text-2xl md:text-3xl font-bold text-foreground">Favorites</h2>
+				<p className="text-sm text-muted-foreground mt-1">
+					{favorites.length} {favorites.length === 1 ? 'item' : 'items'} saved
+				</p>
+			</div>
+
+			{movieFavorites.length > 0 && (
+				<div className="space-y-6">
+					<div>
+						<h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">Movies</h3>
+						<p className="text-sm text-muted-foreground">{movieFavorites.length} movies</p>
+					</div>
+					<div
+						className={cn(
+							'grid gap-4 md:gap-6',
+							'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'
+						)}
+					>
+						{movieFavorites.map((show, index) => (
+							<MediaCard key={show.id} type="movie" show={show} index={index} isVertical />
+						))}
+					</div>
+				</div>
+			)}
+
+			{tvFavorites.length > 0 && (
+				<div className="space-y-6">
+					<div>
+						<h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">TV Shows</h3>
+						<p className="text-sm text-muted-foreground">{tvFavorites.length} shows</p>
+					</div>
+					<div
+						className={cn(
+							'grid gap-4 md:gap-6',
+							'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'
+						)}
+					>
+						{tvFavorites.map((show, index) => (
+							<MediaCard key={show.id} type="tv" show={show} index={index} isVertical />
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+

--- a/components/features/watchlist/library-watchlist.tsx
+++ b/components/features/watchlist/library-watchlist.tsx
@@ -1,112 +1,107 @@
-'use client';
+'use client'
 
-import React, { useMemo } from 'react';
-import { Show } from '@/lib/types';
-import useWatchListStore from '@/store/watchlistStore';
-import MediaCard from '@/components/features/media/card/media-card';
-import { useHasMounted } from '@/hooks/use-has-mounted';
-import { Bookmark } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from 'react'
+import { Bookmark } from 'lucide-react'
+
+import type { Show } from '@/lib/types'
+import useWatchListStore from '@/store/watchlistStore'
+import MediaCard from '@/components/features/media/card/media-card'
+import { useHasMounted } from '@/hooks/use-has-mounted'
+import { cn } from '@/lib/utils'
 
 export function LibraryWatchlist() {
-    const hasMounted = useHasMounted();
-    const { watchlist, tvwatchlist } = useWatchListStore();
+	const hasMounted = useHasMounted()
+	const { watchlist, tvwatchlist } = useWatchListStore()
 
-    const filteredMovieWatchlist = useMemo(() =>
-        watchlist?.filter((show: Show) => show.poster_path || show.backdrop_path) || [],
-        [watchlist]
-    );
+	const filteredMovieWatchlist = React.useMemo(() => {
+		return watchlist?.filter((show: Show) => show.poster_path || show.backdrop_path) || []
+	}, [watchlist])
 
-    const filteredTVWatchlist = useMemo(() =>
-        tvwatchlist?.filter((show: Show) => show.poster_path || show.backdrop_path) || [],
-        [tvwatchlist]
-    );
+	const filteredTVWatchlist = React.useMemo(() => {
+		return tvwatchlist?.filter((show: Show) => show.poster_path || show.backdrop_path) || []
+	}, [tvwatchlist])
 
-    const allItems = [...filteredMovieWatchlist, ...filteredTVWatchlist];
-    const totalCount = allItems.length;
+	const totalCount = filteredMovieWatchlist.length + filteredTVWatchlist.length
 
-    if (!hasMounted) {
-        return (
-            <div className="flex items-center justify-center py-20">
-                <div className="text-center space-y-4">
-                    <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
-                    <p className="text-muted-foreground text-sm">Loading...</p>
-                </div>
-            </div>
-        );
-    }
+	if (!hasMounted) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<div className="text-center space-y-4">
+					<div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
+					<p className="text-muted-foreground text-sm">Loading...</p>
+				</div>
+			</div>
+		)
+	}
 
-    if (totalCount === 0) {
-        return (
-            <div className="flex flex-col items-center justify-center py-20 space-y-4">
-                <div className="w-16 h-16 rounded-full bg-zinc-900 flex items-center justify-center mb-4">
-                    <Bookmark className="w-8 h-8 text-zinc-600" />
-                </div>
-                <h3 className="text-xl font-bold text-foreground">Your watchlist is empty</h3>
-                <p className="text-muted-foreground text-center max-w-md">
-                    Add shows and movies to your watchlist by clicking the bookmark icon on any details page.
-                </p>
-            </div>
-        );
-    }
+	if (totalCount === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center py-20 space-y-4">
+				<div className="w-16 h-16 rounded-full bg-zinc-900 flex items-center justify-center mb-4">
+					<Bookmark className="w-8 h-8 text-zinc-600" />
+				</div>
+				<h3 className="text-xl font-bold text-foreground">Your watchlist is empty</h3>
+				<p className="text-muted-foreground text-center max-w-md">
+					Add shows and movies to your watchlist by clicking the bookmark icon on any details page.
+				</p>
+			</div>
+		)
+	}
 
-    return (
-        <div className="space-y-10">
-            {/* Header */}
-            <div>
-                <h2 className="text-2xl md:text-3xl font-bold text-foreground">My Watchlist</h2>
-                <p className="text-sm text-muted-foreground mt-1">
-                    {totalCount} {totalCount === 1 ? 'item' : 'items'} saved
-                </p>
-            </div>
+	return (
+		<div className="space-y-10">
+			<div>
+				<h2 className="text-2xl md:text-3xl font-bold text-foreground">My Watchlist</h2>
+				<p className="text-sm text-muted-foreground mt-1">
+					{totalCount} {totalCount === 1 ? 'item' : 'items'} saved
+				</p>
+			</div>
 
-            {/* Movies Section */}
-            {filteredMovieWatchlist.length > 0 && (
-                <div className="space-y-6">
-                    <div>
-                        <h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">Movies</h3>
-                        <p className="text-sm text-muted-foreground">{filteredMovieWatchlist.length} movies</p>
-                    </div>
-                    <div className={cn(
-                        "grid gap-4 md:gap-6",
-                        "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-                    )}>
-                        {filteredMovieWatchlist.map((show, index) => (
-                            <MediaCard
-                                key={show.id}
-                                type="movie"
-                                show={show}
-                                index={index}
-                                isVertical={true}
-                            />
-                        ))}
-                    </div>
-                </div>
-            )}
+			{filteredMovieWatchlist.length > 0 && (
+				<div className="space-y-6">
+					<div>
+						<h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">Movies</h3>
+						<p className="text-sm text-muted-foreground">
+							{filteredMovieWatchlist.length} movies
+						</p>
+					</div>
+					<div
+						className={cn(
+							'grid gap-4 md:gap-6',
+							'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'
+						)}
+					>
+						{filteredMovieWatchlist.map((show, index) => (
+							<MediaCard
+								key={show.id}
+								type="movie"
+								show={show}
+								index={index}
+								isVertical
+							/>
+						))}
+					</div>
+				</div>
+			)}
 
-            {/* TV Shows Section */}
-            {filteredTVWatchlist.length > 0 && (
-                <div className="space-y-6">
-                    <div>
-                        <h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">TV Shows</h3>
-                        <p className="text-sm text-muted-foreground">{filteredTVWatchlist.length} shows</p>
-                    </div>
-                    <div className={cn(
-                        "grid gap-4 md:gap-6",
-                        "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-                    )}>
-                        {filteredTVWatchlist.map((show, index) => (
-                            <MediaCard
-                                key={show.id}
-                                type="tv"
-                                show={show}
-                                index={index}
-                                isVertical={true}
-                            />
-                        ))}
-                    </div>
-                </div>
-            )}
-        </div>
-    );
+			{filteredTVWatchlist.length > 0 && (
+				<div className="space-y-6">
+					<div>
+						<h3 className="text-lg md:text-xl font-semibold text-foreground mb-1">TV Shows</h3>
+						<p className="text-sm text-muted-foreground">{filteredTVWatchlist.length} shows</p>
+					</div>
+					<div
+						className={cn(
+							'grid gap-4 md:gap-6',
+							'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'
+						)}
+					>
+						{filteredTVWatchlist.map((show, index) => (
+							<MediaCard key={show.id} type="tv" show={show} index={index} isVertical />
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	)
 }

--- a/components/layout/header/header.tsx
+++ b/components/layout/header/header.tsx
@@ -10,8 +10,9 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useSidebar } from '@/components/ui/sidebar';
 import { HeaderActions } from './header-actions';
 import { HeaderNavigation } from './header-navigation';
-import { navigationItems } from './navigation-data';
+import { getNavigationItems } from './navigation-data';
 import { cn } from '@/lib/utils';
+import { useSession } from '@/lib/auth-client';
 
 interface HeaderProps {
 	className?: string;
@@ -34,6 +35,10 @@ export function Header({ className }: HeaderProps) {
 	const [scrolled, setScrolled] = React.useState(false);
 	const pathname = usePathname();
 	const { toggleSidebar, openMobile } = useSidebar();
+	const { data: session } = useSession();
+	const navigationItems = React.useMemo(() => {
+		return getNavigationItems({ isSignedIn: Boolean(session?.user?.id) });
+	}, [session?.user?.id]);
 
 	// Apple-style scroll detection with passive listener and hysteresis
 	React.useEffect(() => {

--- a/components/layout/header/header.tsx
+++ b/components/layout/header/header.tsx
@@ -32,9 +32,8 @@ interface HeaderProps {
  */
 export function Header({ className }: HeaderProps) {
 	const [scrolled, setScrolled] = React.useState(false);
-	const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
 	const pathname = usePathname();
-	const { toggleSidebar } = useSidebar();
+	const { toggleSidebar, openMobile } = useSidebar();
 
 	// Apple-style scroll detection with passive listener and hysteresis
 	React.useEffect(() => {
@@ -53,11 +52,6 @@ export function Header({ className }: HeaderProps) {
 		window.addEventListener('scroll', handleScroll, { passive: true });
 		return () => window.removeEventListener('scroll', handleScroll);
 	}, []);
-
-	// Close mobile menu on route change
-	React.useEffect(() => {
-		setMobileMenuOpen(false);
-	}, [pathname]);
 
 	const isActive = (href: string) => {
 		if (href === '/') {
@@ -211,12 +205,12 @@ export function Header({ className }: HeaderProps) {
 									'touch-manipulation',
 									'group'
 								)}
-								aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-								aria-expanded={mobileMenuOpen}
+								aria-label={openMobile ? 'Close menu' : 'Open menu'}
+								aria-expanded={openMobile}
 							>
 								<div className="relative w-5 h-5 flex items-center justify-center">
 									<AnimatePresence mode="wait" initial={false}>
-										{mobileMenuOpen ? (
+										{openMobile ? (
 											<motion.div
 												key="close"
 												initial={{ rotate: -90, opacity: 0, scale: 0.8 }}

--- a/components/layout/header/header.tsx
+++ b/components/layout/header/header.tsx
@@ -10,9 +10,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useSidebar } from '@/components/ui/sidebar';
 import { HeaderActions } from './header-actions';
 import { HeaderNavigation } from './header-navigation';
-import { getNavigationItems } from './navigation-data';
+import { navigationItems } from './navigation-data';
 import { cn } from '@/lib/utils';
-import { useSession } from '@/lib/auth-client';
 
 interface HeaderProps {
 	className?: string;
@@ -35,10 +34,6 @@ export function Header({ className }: HeaderProps) {
 	const [scrolled, setScrolled] = React.useState(false);
 	const pathname = usePathname();
 	const { toggleSidebar, openMobile } = useSidebar();
-	const { data: session } = useSession();
-	const navigationItems = React.useMemo(() => {
-		return getNavigationItems({ isSignedIn: Boolean(session?.user?.id) });
-	}, [session?.user?.id]);
 
 	// Apple-style scroll detection with passive listener and hysteresis
 	React.useEffect(() => {

--- a/components/layout/header/mobile-header.tsx
+++ b/components/layout/header/mobile-header.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Home, Search, MenuSquare, User, List } from 'lucide-react';
+import { Home, Search, MenuSquare, User, Bookmark } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { useSidebar } from '@/components/ui/sidebar';
@@ -13,7 +13,7 @@ interface MobileHeaderProps {
 }
 
 interface MobileNavItem {
-	id: 'home' | 'search' | 'explore' | 'lists' | 'account';
+	id: 'home' | 'search' | 'explore' | 'library' | 'account';
 	label: string;
 	icon: React.ReactNode;
 	href?: string;
@@ -89,9 +89,9 @@ export default function MobileHeader({ center }: MobileHeaderProps) {
 	const { toggleSidebar } = useSidebar();
 	const { data: session } = useSession();
 
-	const profileHref = session?.user?.id
-		? '/profile'
-		: '/auth/signin?callbackUrl=/profile';
+	const accountHref = session?.user?.id ? '/profile' : '/auth/signin?callbackUrl=/profile';
+	const libraryHref = session?.user?.id ? '/library' : '/auth/signin?callbackUrl=/library';
+	const libraryLabel = session?.user?.id ? 'Library' : 'Sign in first';
 
 	const handleNavigate = React.useCallback(
 		(href: string) => {
@@ -105,14 +105,15 @@ export default function MobileHeader({ center }: MobileHeaderProps) {
 			{ id: 'home', label: 'Home', icon: <Home className="h-4 w-4" />, href: '/' },
 			{ id: 'search', label: 'Search', icon: <Search className="h-4 w-4" />, href: '/search' },
 			{ id: 'explore', label: 'Explore', icon: <MenuSquare className="h-4 w-4" />, onClick: toggleSidebar },
-			{ id: 'lists', label: 'My Lists', icon: <List className="h-4 w-4" />, href: profileHref },
-			{ id: 'account', label: 'Profile', icon: <User className="h-4 w-4" />, href: profileHref },
+			{ id: 'library', label: libraryLabel, icon: <Bookmark className="h-4 w-4" />, href: libraryHref },
+			{ id: 'account', label: 'Profile', icon: <User className="h-4 w-4" />, href: accountHref },
 		];
-	}, [toggleSidebar, profileHref]);
+	}, [toggleSidebar, libraryLabel, libraryHref, accountHref]);
 
 	const selectedId = React.useMemo<MobileNavItem['id']>(() => {
 		if (pathname === '/') return 'home';
 		if (pathname.startsWith('/search')) return 'search';
+		if (pathname.startsWith('/library')) return 'library';
 		if (pathname.startsWith('/profile')) return 'account';
 		return 'home';
 	}, [pathname]);

--- a/components/layout/header/mobile-header.tsx
+++ b/components/layout/header/mobile-header.tsx
@@ -90,8 +90,8 @@ export default function MobileHeader({ center }: MobileHeaderProps) {
 	const { data: session } = useSession();
 
 	const accountHref = session?.user?.id ? '/profile' : '/auth/signin?callbackUrl=/profile';
-	const libraryHref = session?.user?.id ? '/library' : '/auth/signin?callbackUrl=/library';
-	const libraryLabel = session?.user?.id ? 'Library' : 'Sign in first';
+	const libraryHref = '/library';
+	const libraryLabel = 'Library';
 
 	const handleNavigate = React.useCallback(
 		(href: string) => {

--- a/components/layout/header/mobile-header.tsx
+++ b/components/layout/header/mobile-header.tsx
@@ -1,25 +1,24 @@
 'use client';
-import { useState, ReactNode } from 'react';
+import * as React from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
-import {
-	Fingerprint,
-	Info,
-	CircleDollarSign,
-	Newspaper,
-	User,
-	Home,
-	Search,
-	Sun,
-	MenuSquare,
-} from 'lucide-react';
+import { Home, Search, MenuSquare, User, List } from 'lucide-react';
 
-const tabs = [
-	{ title: 'Home', icon: <Home /> },
-	{ title: 'Search', icon: <Search /> },
-	{ title: 'Theme', icon: <Sun /> },
-	{ title: 'Explore', icon: <MenuSquare /> },
-	{ title: 'Profile', icon: <User /> },
-];
+import { cn } from '@/lib/utils';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useSession } from '@/lib/auth-client';
+
+interface MobileHeaderProps {
+	center?: boolean;
+}
+
+interface MobileNavItem {
+	id: 'home' | 'search' | 'explore' | 'lists' | 'account';
+	label: string;
+	icon: React.ReactNode;
+	href?: string;
+	onClick?: () => void;
+}
 
 const buttonVariants = {
 	initial: {
@@ -27,14 +26,14 @@ const buttonVariants = {
 		paddingLeft: '.5rem',
 		paddingRight: '.5rem',
 	},
-	animate: (selected: boolean) => ({
-		gap: selected ? '.5rem' : 0,
-		paddingLeft: selected ? '1rem' : '.5rem',
-		paddingRight: selected ? '1rem' : '.5rem',
+	animate: (isSelected: boolean) => ({
+		gap: isSelected ? '.5rem' : 0,
+		paddingLeft: isSelected ? '1rem' : '.5rem',
+		paddingRight: isSelected ? '1rem' : '.5rem',
 	}),
 };
 
-const spanVariants = {
+const labelVariants = {
 	initial: { width: 0, opacity: 0 },
 	animate: { width: 'auto', opacity: 1 },
 	exit: { width: 0, opacity: 0 },
@@ -42,72 +41,109 @@ const spanVariants = {
 
 const transition = { delay: 0.1, type: 'spring', bounce: 0, duration: 0.35 };
 
-interface TabProps {
-	text: string;
-	selected: boolean;
-	setSelected: (tab: Object) => void;
-	children: ReactNode;
-	index: number;
+interface TabButtonProps {
+	label: string;
+	icon: React.ReactNode;
+	isSelected: boolean;
+	onSelect: () => void;
 }
 
-const Tab = ({ text, selected, setSelected, index, children }: TabProps) => {
+function TabButton({ label, icon, isSelected, onSelect }: TabButtonProps) {
 	return (
 		<motion.button
 			variants={buttonVariants}
 			initial="initial"
 			animate="animate"
-			custom={selected}
-			onClick={() => setSelected(tabs[index])}
+			custom={isSelected}
+			onClick={onSelect}
 			transition={transition}
-			className={`${
-				selected ? 'bg-primary text-primary-foreground ' : ''
-			} relative flex items-center rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors duration-300 focus-within:outline-red-500/50`}
+			className={cn(
+				'relative flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors duration-300',
+				'text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+				isSelected && 'bg-primary text-primary-foreground'
+			)}
+			aria-current={isSelected ? 'page' : undefined}
 		>
-			{children}
+			{icon}
 			<AnimatePresence>
-				{selected && (
+				{isSelected && (
 					<motion.span
-						variants={spanVariants}
+						variants={labelVariants}
 						initial="initial"
 						animate="animate"
 						exit="exit"
 						transition={transition}
 						className="overflow-hidden"
 					>
-						{text}
+						{label}
 					</motion.span>
 				)}
 			</AnimatePresence>
 		</motion.button>
 	);
-};
+}
 
-// IconTabs component
-const MobileHeader = ({ center }: { center?: boolean }) => {
-	// State to manage selected tab
-	const [selected, setSelected] = useState<Object>(tabs[0]);
+export default function MobileHeader({ center }: MobileHeaderProps) {
+	const pathname = usePathname();
+	const router = useRouter();
+	const { toggleSidebar } = useSidebar();
+	const { data: session } = useSession();
+
+	const profileHref = session?.user?.id
+		? '/profile'
+		: '/auth/signin?callbackUrl=/profile';
+
+	const handleNavigate = React.useCallback(
+		(href: string) => {
+			router.push(href);
+		},
+		[router]
+	);
+
+	const navItems = React.useMemo<MobileNavItem[]>(() => {
+		return [
+			{ id: 'home', label: 'Home', icon: <Home className="h-4 w-4" />, href: '/' },
+			{ id: 'search', label: 'Search', icon: <Search className="h-4 w-4" />, href: '/search' },
+			{ id: 'explore', label: 'Explore', icon: <MenuSquare className="h-4 w-4" />, onClick: toggleSidebar },
+			{ id: 'lists', label: 'My Lists', icon: <List className="h-4 w-4" />, href: profileHref },
+			{ id: 'account', label: 'Profile', icon: <User className="h-4 w-4" />, href: profileHref },
+		];
+	}, [toggleSidebar, profileHref]);
+
+	const selectedId = React.useMemo<MobileNavItem['id']>(() => {
+		if (pathname === '/') return 'home';
+		if (pathname.startsWith('/search')) return 'search';
+		if (pathname.startsWith('/profile')) return 'account';
+		return 'home';
+	}, [pathname]);
+
+	const handleSelect = React.useCallback(
+		(item: MobileNavItem) => {
+			if (item.onClick) item.onClick();
+			if (item.href) handleNavigate(item.href);
+		},
+		[handleNavigate]
+	);
 
 	return (
-		<div
-			className={`fixed bottom-0 left-0 right-0 ${
-				center ? 'justify-center' : ''
-			} mb-8 r z-30 gap-2  justify-center items-center flex border-gray-200 pb-2 dark:border-gray-600`}
+		<nav
+			className={cn(
+				'fixed bottom-0 left-0 right-0 z-30 flex items-center justify-center pb-2',
+				center && 'justify-center'
+			)}
+			aria-label="Bottom navigation"
 		>
-			<div className="flex p-2 bg-background w-fit rounded-full flex-wrap items-center">
-				{tabs.map((tab, index) => (
-					<Tab
-						text={tab.title}
-						selected={selected === tab}
-						setSelected={setSelected}
-						index={index}
-						key={tab.title}
-					>
-						{tab.icon}
-					</Tab>
+			<div className="mb-6 flex w-fit flex-wrap items-center rounded-full bg-background/90 p-2 backdrop-blur-md border border-border/50">
+				{navItems.map((navItem) => (
+					<TabButton
+						key={navItem.id}
+						label={navItem.label}
+						icon={navItem.icon}
+						isSelected={selectedId === navItem.id}
+						onSelect={() => handleSelect(navItem)}
+					/>
 				))}
 			</div>
-		</div>
+		</nav>
 	);
-};
-
-export default MobileHeader;
+}

--- a/components/layout/header/navigation-data.ts
+++ b/components/layout/header/navigation-data.ts
@@ -107,14 +107,6 @@ export const navigationItems: NavigationItem[] = [
 ];
 
 export function getNavigationItems(options: { isSignedIn: boolean }) {
-	if (options.isSignedIn) return navigationItems;
-
-	return navigationItems.map((item) => {
-		if (item.href !== '/library') return item;
-		return {
-			...item,
-			label: 'Sign in first',
-			href: '/auth/signin?callbackUrl=/library',
-		};
-	});
+	void options;
+	return navigationItems;
 }

--- a/components/layout/header/navigation-data.ts
+++ b/components/layout/header/navigation-data.ts
@@ -2,7 +2,7 @@ import {
 	Home,
 	Clapperboard,
 	Tv,
-	List,
+	Bookmark,
 	Sparkles,
 	Play,
 	Heart,
@@ -100,8 +100,21 @@ export const navigationItems: NavigationItem[] = [
 		],
 	},
 	{
-		label: 'My Lists',
-		href: '/profile',
-		icon: List,
+		label: 'Library',
+		href: '/library',
+		icon: Bookmark,
 	},
 ];
+
+export function getNavigationItems(options: { isSignedIn: boolean }) {
+	if (options.isSignedIn) return navigationItems;
+
+	return navigationItems.map((item) => {
+		if (item.href !== '/library') return item;
+		return {
+			...item,
+			label: 'Sign in first',
+			href: '/auth/signin?callbackUrl=/library',
+		};
+	});
+}

--- a/components/layout/sidebar/app-sidebar.tsx
+++ b/components/layout/sidebar/app-sidebar.tsx
@@ -17,10 +17,9 @@ import {
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { SearchCommandBox } from '@/components/features/search/search-command-box';
-import { getNavigationItems } from '../header/navigation-data';
+import { navigationItems } from '../header/navigation-data';
 import { cn } from '@/lib/utils';
 import { AuthButton } from '@/components/auth/auth-button';
-import { useSession } from '@/lib/auth-client';
 
 /**
  * AppSidebar - Apple-inspired mobile navigation sidebar
@@ -36,10 +35,6 @@ export function AppSidebar() {
 	const { setOpenMobile } = useSidebar();
 	const [openSections, setOpenSections] = React.useState<Set<string>>(new Set());
 	const pathname = usePathname();
-	const { data: session } = useSession();
-	const navigationItems = React.useMemo(() => {
-		return getNavigationItems({ isSignedIn: Boolean(session?.user?.id) });
-	}, [session?.user?.id]);
 
 	// Auto-expand sections if current path matches
 	React.useEffect(() => {

--- a/components/layout/sidebar/app-sidebar.tsx
+++ b/components/layout/sidebar/app-sidebar.tsx
@@ -17,9 +17,10 @@ import {
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { SearchCommandBox } from '@/components/features/search/search-command-box';
-import { navigationItems } from '../header/navigation-data';
+import { getNavigationItems } from '../header/navigation-data';
 import { cn } from '@/lib/utils';
 import { AuthButton } from '@/components/auth/auth-button';
+import { useSession } from '@/lib/auth-client';
 
 /**
  * AppSidebar - Apple-inspired mobile navigation sidebar
@@ -35,6 +36,10 @@ export function AppSidebar() {
 	const { setOpenMobile } = useSidebar();
 	const [openSections, setOpenSections] = React.useState<Set<string>>(new Set());
 	const pathname = usePathname();
+	const { data: session } = useSession();
+	const navigationItems = React.useMemo(() => {
+		return getNavigationItems({ isSignedIn: Boolean(session?.user?.id) });
+	}, [session?.user?.id]);
 
 	// Auto-expand sections if current path matches
 	React.useEffect(() => {

--- a/components/layout/sidebar/navigation-sidebar.tsx
+++ b/components/layout/sidebar/navigation-sidebar.tsx
@@ -7,8 +7,6 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from '@/components/ui/sheet';
-import { fetchGenres } from '@/lib/api';
-import { Button } from '@/components/ui/button';
 import { TabsContent, Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import Link from 'next/link';
 import { TextGlitch } from '@/components/shared/animated/text-glitch';
@@ -21,8 +19,8 @@ const NavigationSidebar = (props: { tvGenre: any; movieGenre: any }) => {
 				<SheetHeader>
 					<SheetTitle className=" p-2 text-xl ">Explore</SheetTitle>
 					<SheetDescription>
-						<Tabs className=" w-full lg:max-w-[80%]">
-							<TabsList className=" flex w-full bg-background" defaultValue={'tv'}>
+						<Tabs className=" w-full lg:max-w-[80%]" defaultValue="tv">
+							<TabsList className=" flex w-full bg-background">
 								<TabsTrigger className="w-full" value="movies">
 									Movies{' '}
 								</TabsTrigger>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -665,10 +665,8 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+  // Keep deterministic to avoid hydration/render mismatches.
+  const width = "70%"
 
   return (
     <div

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,11 @@
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+
+export default [
+  ...nextCoreWebVitals,
+  {
+    rules: {
+      '@next/next/no-img-element': 'off'
+    }
+  }
+]
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
 				"@types/react-dom": "19.1.3",
 				"autoprefixer": "latest",
 				"dotenv": "^17.2.3",
-				"eslint": "latest",
+				"eslint": "^9.26.0",
 				"eslint-config-next": "^16.0.0",
 				"postcss": "latest",
 				"prettier": "^3.3.3",
@@ -1861,9 +1861,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1890,13 +1890,13 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-			"integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.6",
+				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
 				"minimatch": "^3.1.2"
 			},
@@ -1905,19 +1905,22 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-			"integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-			"integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1928,9 +1931,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1940,7 +1943,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
+				"js-yaml": "^4.1.1",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -1952,19 +1955,22 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-			"integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
+			"version": "9.39.2",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1972,13 +1978,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-			"integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.13.0",
+				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -2059,31 +2065,17 @@
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.6",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
-				"@humanwhocodes/retry": "^0.3.0"
+				"@humanwhocodes/retry": "^0.4.0"
 			},
 			"engines": {
 				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -2678,28 +2670,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-			"integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"cors": "^2.8.5",
-				"cross-spawn": "^7.0.3",
-				"eventsource": "^3.0.2",
-				"express": "^5.0.1",
-				"express-rate-limit": "^7.5.0",
-				"pkce-challenge": "^5.0.0",
-				"raw-body": "^3.0.0",
-				"zod": "^3.23.8",
-				"zod-to-json-schema": "^3.24.1"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@mrleebo/prisma-ast": {
@@ -6287,43 +6257,6 @@
 				"node": ">=18.14"
 			}
 		},
-		"node_modules/accepts": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-types": "^3.0.0",
-				"negotiator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6922,27 +6855,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/body-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
-				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7024,16 +6936,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/bytes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/c12": {
@@ -7621,53 +7523,10 @@
 				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
-		"node_modules/content-disposition": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.6.0"
-			}
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.33.0",
@@ -7679,20 +7538,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
-			}
-		},
-		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -8104,16 +7949,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/destr": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -8196,13 +8031,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/effect": {
 			"version": "3.18.4",
@@ -8299,16 +8127,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/encodeurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -8504,13 +8322,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -8524,34 +8335,32 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
-			"integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
+			"version": "9.39.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.20.0",
-				"@eslint/config-helpers": "^0.2.1",
-				"@eslint/core": "^0.13.0",
+				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.26.0",
-				"@eslint/plugin-kit": "^0.2.8",
+				"@eslint/js": "9.39.2",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
-				"@modelcontextprotocol/sdk": "^1.8.0",
 				"@types/estree": "^1.0.6",
-				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.3.0",
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
 				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -8565,8 +8374,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"zod": "^3.24.2"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -8846,9 +8654,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-			"integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -8875,9 +8683,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -8888,15 +8696,15 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.0"
+				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8906,9 +8714,9 @@
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -8935,6 +8743,7 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -8964,126 +8773,11 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"license": "MIT"
-		},
-		"node_modules/eventsource": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eventsource-parser": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/eventsource-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/express": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "^2.0.0",
-				"body-parser": "^2.2.0",
-				"content-disposition": "^1.0.0",
-				"content-type": "^1.0.5",
-				"cookie": "^0.7.1",
-				"cookie-signature": "^1.2.1",
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"finalhandler": "^2.1.0",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"merge-descriptors": "^2.0.0",
-				"mime-types": "^3.0.0",
-				"on-finished": "^2.4.1",
-				"once": "^1.4.0",
-				"parseurl": "^1.3.3",
-				"proxy-addr": "^2.0.7",
-				"qs": "^6.14.0",
-				"range-parser": "^1.2.1",
-				"router": "^2.2.0",
-				"send": "^1.1.0",
-				"serve-static": "^2.2.0",
-				"statuses": "^2.0.1",
-				"type-is": "^2.0.1",
-				"vary": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express-rate-limit": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-			"integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/express-rate-limit"
-			},
-			"peerDependencies": {
-				"express": "^4.11 || 5 || ^5.0.0-beta.1"
-			}
-		},
-		"node_modules/express/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/express/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/exsolve": {
 			"version": "1.0.8",
@@ -9244,24 +8938,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/finalhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-			"integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"on-finished": "^2.4.1",
-				"parseurl": "^1.3.3",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/find-cache-dir": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -9379,16 +9055,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/fraction.js": {
 			"version": "4.3.6",
 			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
@@ -9427,16 +9093,6 @@
 				"react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -9842,23 +9498,6 @@
 				"node": ">=16.9.0"
 			}
 		},
-		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/http-status-codes": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
@@ -9872,19 +9511,6 @@
 			"integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
 			"engines": {
 				"node": ">=0.4"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/idb": {
@@ -9972,16 +9598,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -10255,13 +9871,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/is-promise": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -10523,9 +10132,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11057,29 +10666,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/media-typer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11301,16 +10887,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/negotiator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/next": {
 			"version": "16.1.1",
@@ -13974,19 +13550,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14088,16 +13651,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -14133,16 +13686,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
-		"node_modules/path-to-regexp": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-			"integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -14355,16 +13898,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pkce-challenge": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -14639,20 +14172,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -14683,22 +14202,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14724,32 +14227,6 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/rc9": {
@@ -15270,23 +14747,6 @@
 			"integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
 			"license": "MIT"
 		},
-		"node_modules/router": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"depd": "^2.0.0",
-				"is-promise": "^4.0.0",
-				"parseurl": "^1.3.3",
-				"path-to-regexp": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15419,52 +14879,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/send": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.5",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"mime-types": "^3.0.1",
-				"ms": "^2.1.3",
-				"on-finished": "^2.4.1",
-				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/send/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/send/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/seq-queue": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
@@ -15478,22 +14892,6 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
-			}
-		},
-		"node_modules/serve-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-			"integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"parseurl": "^1.3.3",
-				"send": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 18"
 			}
 		},
 		"node_modules/set-cookie-parser": {
@@ -15547,13 +14945,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/sharp": {
 			"version": "0.34.5",
@@ -15793,16 +15184,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/std-env": {
@@ -16302,16 +15683,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/tr46": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -16385,44 +15756,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/type-is/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/type-is/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/typed-array-buffer": {
@@ -16615,16 +15948,6 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -16737,16 +16060,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vaul": {
@@ -17222,16 +16535,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-			"integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-			"dev": true,
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
 			}
 		},
 		"node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"dev": "next dev --turbopack",
 		"build": "next build",
 		"start": "next start",
-		"lint": "next lint",
+		"lint": "eslint .",
 		"postinstall": "prisma generate"
 	},
 	"dependencies": {
@@ -106,7 +106,7 @@
 		"@types/react-dom": "19.1.3",
 		"autoprefixer": "latest",
 		"dotenv": "^17.2.3",
-		"eslint": "latest",
+		"eslint": "^9.26.0",
 		"eslint-config-next": "^16.0.0",
 		"postcss": "latest",
 		"prettier": "^3.3.3",


### PR DESCRIPTION
Implement a dynamic Library page and navigation, adapting to user authentication status, to showcase a production-ready, full-stack feature.

This PR introduces a new `/library` route that soft-guards, displaying a "Sign in first" screen when logged out and a revamped Library page when logged in. Navigation items (header, sidebar, mobile nav) now dynamically update their label and href based on authentication. The Library page itself features hero sections, stats cards, and a tabbed layout for "Continue watching", "Watchlist", and "Favorites". Additionally, this PR includes fixes for several UI bugs (e.g., mobile nav routing, hamburger icon state, tab default values) and migrates ESLint to Next.js 16's flat config.

---
<a href="https://cursor.com/background-agent?bcId=bc-81401c3a-108c-4afd-96d5-45564e601feb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81401c3a-108c-4afd-96d5-45564e601feb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Delivers a production-ready Library experience with dynamic auth-aware data and navigation.
> 
> - Adds `app/library/page.tsx` featuring hero, stat cards, and tabbed sections: `Continue watching`, `Watchlist`, `Favorites`; counts derive from local stores or DB via `useUser*` hooks and show sign-in CTA when logged out
> - New `components/features/watchlist/library-favorites-synced.tsx` to resolve favorites (dedupes, loads missing details) and render by media type; refines `LibraryWatchlist`
> - Navigation/UI fixes: header hamburger now bound to sidebar `openMobile` state and ARIA reflects state; revamped mobile bottom nav (`mobile-header.tsx`) with `Library` tab and correct route selection; updates nav data (`navigation-data.ts`) to `Library` (Bookmark) and adds `getNavigationItems`; sidebar explore tabs set `defaultValue="tv"`; deterministic sidebar skeleton width
> - Profile: sign-out now `await signOut()` then `router.push('/')`
> - Tooling: replace `.eslintrc.json` with `eslint.config.mjs`, update `lint` script to `eslint .`, bump ESLint and deps (lockfile)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e121fd16e8acae395328cda86b63b96dc889c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->